### PR TITLE
Updates to bm2-battery-monitor for python scripts (updated)

### DIFF
--- a/bm2_python/requirements.txt
+++ b/bm2_python/requirements.txt
@@ -1,2 +1,2 @@
 bleak~=0.14.2
-pycrypto~=2.6.1
+pycryptodome~=3.21.0

--- a/bm2_python/src/bm2/client.py
+++ b/bm2_python/src/bm2/client.py
@@ -84,7 +84,7 @@ class BM2Client:
             f = asyncio.Future[List[HistoryReading]]()
             self._future_history_readings = f
             await self._send([0xe7, 1])
-            return await asyncio.wait_for(f, 5)
+            return await asyncio.wait_for(f, 60)
 
     async def get_voltage(self) -> float:
         async with self._request_sem:

--- a/bm2_python/src/bm2/client.py
+++ b/bm2_python/src/bm2/client.py
@@ -81,19 +81,31 @@ class BM2Client:
             if self._stop:
                 raise NotConnectedError()
 
-            f = asyncio.Future[List[HistoryReading]]()
-            self._future_history_readings = f
-            await self._send([0xe7, 1])
-            return await asyncio.wait_for(f, 60)
+            try:
+                f = asyncio.Future[List[HistoryReading]]()
+                self._future_history_readings = f
+                await self._send([0xe7, 1])
+                return await asyncio.wait_for(f, 60)
+            except TimeoutError:
+                logger.error(f"get_history Timeout error : {self._mac}")
+                return []
+            except Exception as e:
+                logger.error(f"get_history Exception: {e} : {self._mac}")
+                return []
 
     async def get_voltage(self) -> float:
         async with self._request_sem:
             if self._stop:
                 raise NotConnectedError()
 
-            f = asyncio.Future[float]()
-            self._future_voltage_reading = f
-            return await asyncio.wait_for(f, 60)
+            try:
+                f = asyncio.Future[float]()
+                self._future_voltage_reading = f
+                return await asyncio.wait_for(f, 60)
+            except TimeoutError:
+                logger.error(f"get_voltage Timeout error : {self._mac}")
+            except Exception as e:
+                logger.error(f"get_history Exception: {e} : {self._mac}")
 
     async def _send(self, data: List[int]) -> None:
         await self.wait_for_connected()

--- a/bm2_python/src/bm2/client.py
+++ b/bm2_python/src/bm2/client.py
@@ -13,7 +13,7 @@ from bleak import BleakClient
 import bleak.exc
 
 from bm2.bit_utils import decode_3bytes, decode_nibbles
-from bm2.encryption import encrypt, decrypt
+from bm2.encryption import encrypt, decrypt, decrypt_all_blocks
 
 logger = logging.getLogger("bm2_client")
 
@@ -137,7 +137,7 @@ class BM2Client:
                 await asyncio.sleep(1)
 
     def _notification_handler(self, _: Any, encrypted_data: bytearray) -> None:
-        decrypted_data = decrypt(encrypted_data)
+        decrypted_data = decrypt_all_blocks(encrypted_data)
 
         def is_of_type(packet_type: PacketType) -> bool:
             return decrypted_data[0:len(packet_type.value)] == packet_type.value

--- a/bm2_python/src/bm2/client.py
+++ b/bm2_python/src/bm2/client.py
@@ -80,11 +80,11 @@ class BM2Client:
                 return False
             else:
                 logger.error(f"BleakError during discovery {e} : {self._mac}")
+                if "No powered Bluetooth adapters found." in e.args[0]:
+                    raise Exception("No powered Bluetooth adapters found.")
                 return False
         except Exception as e:
             logger.error(f"Discovery error {e} : {self._mac}")
-            if "No powered Bluetooth adapters found." in e.args[0]:
-                raise Exception("No powered Bluetooth adapters found.")
             return False
 
     def start(self) -> None:

--- a/bm2_python/src/bm2/client.py
+++ b/bm2_python/src/bm2/client.py
@@ -13,7 +13,7 @@ from bleak import BleakClient
 import bleak.exc
 
 from bm2.bit_utils import decode_3bytes, decode_nibbles
-from bm2.encryption import encrypt, decrypt
+from bm2.encryption import encrypt, decrypt, decrypt_all_blocks
 
 logger = logging.getLogger("bm2_client")
 

--- a/bm2_python/src/bm2/encryption.py
+++ b/bm2_python/src/bm2/encryption.py
@@ -1,6 +1,6 @@
 from typing import Any, cast, Union
 
-from Crypto.Cipher import AES
+from Cryptodome.Cipher import AES
 
 BM2_ENCRYPTION_KEY = b"\x6c\x65\x61\x67\x65\x6e\x64\xff\xfe\x31\x38\x38\x32\x34\x36\x36"
 
@@ -22,3 +22,7 @@ def encrypt(data: bytes) -> bytes:
 
 def decrypt(encrypted_data: Union[bytes, bytearray]) -> bytes:
     return cast(bytes, create_aes().decrypt(bytes(encrypted_data)))
+
+def decrypt_all_blocks(data: bytes) -> bytes:
+    assert len(data) % 16 == 0, "Encrypted data must be a multiple of 16 bytes"
+    return b''.join(decrypt(data[i:i+16]) for i in range(0, len(data), 16))


### PR DESCRIPTION
Updates scripts to use pycryptodome as pycrypto package no longer works
Updated exception handling to allow system to self recover from exceptions (useful when monitoring several BM2 devices that come and go out of range)
Adds mac address to logging messages so it's clear which device generated log messages
Fixes bug in data decryption where only the first 16 bytes of received data was being decrypted, at least some BM2 devices sent data packets larger than 16 bytes when sending history data and not all history data had been getting decrypted.
Updated timeout on get_history as existing timeout was shorter than get_voltage timeout and was constantly timing out